### PR TITLE
Now moves forward and back

### DIFF
--- a/ViewMover/Base.lproj/Main.storyboard
+++ b/ViewMover/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -20,7 +20,6 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ndj-cl-KuB">
                                 <rect key="frame" x="40" y="40" width="200" height="128"/>
-                                <animations/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="b5R-Ja-Jt2"/>
@@ -29,29 +28,21 @@
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Fjl-dn-Sho">
                                 <rect key="frame" x="262" y="517" width="75" height="30"/>
-                                <animations/>
                                 <state key="normal" title="Move View"/>
                                 <connections>
                                     <action selector="moveButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="orS-9d-lUG"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="trailingMargin" secondItem="ndj-cl-KuB" secondAttribute="trailing" constant="20" id="2UI-mf-ijE"/>
-                            <constraint firstItem="ndj-cl-KuB" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="20" id="8AD-wH-hGX"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="ndj-cl-KuB" secondAttribute="trailing" priority="250" constant="20" id="2UI-mf-ijE"/>
+                            <constraint firstItem="ndj-cl-KuB" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" priority="750" constant="20" id="8AD-wH-hGX"/>
                             <constraint firstItem="Fjl-dn-Sho" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="ITK-oc-W9e"/>
-                            <constraint firstItem="ndj-cl-KuB" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="20" id="J1L-Bh-h3A"/>
-                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="ndj-cl-KuB" secondAttribute="bottom" constant="208" id="ML2-cm-jJA"/>
+                            <constraint firstItem="ndj-cl-KuB" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" priority="750" constant="20" id="J1L-Bh-h3A"/>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="ndj-cl-KuB" secondAttribute="bottom" priority="250" constant="208" id="ML2-cm-jJA"/>
                             <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="Fjl-dn-Sho" secondAttribute="bottom" constant="53" id="pzB-ps-Wm4"/>
                         </constraints>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="2UI-mf-ijE"/>
-                                <exclude reference="ML2-cm-jJA"/>
-                            </mask>
-                        </variation>
                     </view>
                     <connections>
                         <outlet property="bottomConstraint" destination="ML2-cm-jJA" id="5Vj-Ol-C7U"/>

--- a/ViewMover/ViewController.m
+++ b/ViewMover/ViewController.m
@@ -22,15 +22,24 @@
 
 - (IBAction)moveButtonTapped:(id)sender {
     [UIView animateWithDuration:0.3 animations:^{
-        // Move to right
-        self.leadingConstraint.active = false;
-        self.trailingConstraint.active = true;
-
-        // Move to bottom
-        self.topConstraint.active = false;
-        self.bottomConstraint.active = true;
-
-        [self.view setNeedsLayout];
+        if(self.leadingConstraint.priority == UILayoutPriorityDefaultHigh){
+            // Move to right
+            self.leadingConstraint.priority = UILayoutPriorityDefaultLow;
+            self.trailingConstraint.priority = UILayoutPriorityDefaultHigh;
+            
+            // Move to bottom
+            self.topConstraint.priority = UILayoutPriorityDefaultLow;
+            self.bottomConstraint.priority = UILayoutPriorityDefaultHigh;
+        }
+        else{
+            // move back to left
+            self.leadingConstraint.priority = UILayoutPriorityDefaultHigh;
+            self.trailingConstraint.priority = UILayoutPriorityDefaultLow;
+            
+            // Move back to top
+            self.topConstraint.priority = UILayoutPriorityDefaultHigh;
+            self.bottomConstraint.priority = UILayoutPriorityDefaultLow;
+        }
         [self.view layoutIfNeeded];
     }];
 }


### PR DESCRIPTION
Changed to use priorities instead of active. This allows the view to be
moved back to where it was an allows  better visualisation of
constraints in Xcode because the lower priority ones have dotted lines
and also appear in the views constraint inspector, the uninstalled ones
didn’t.
